### PR TITLE
Simplify math and tidy

### DIFF
--- a/frontend/src/components/Defs.jsx
+++ b/frontend/src/components/Defs.jsx
@@ -1,4 +1,4 @@
-import { getFillStyle } from '../utils/style.js'
+import { getFillStyle } from '../utils/style'
 
 const Defs = ({ panel }) => {
   const lineWidth = panel.style.lineWidth

--- a/frontend/src/components/Panel.jsx
+++ b/frontend/src/components/Panel.jsx
@@ -1,6 +1,6 @@
 import { getFillStyle } from '../utils/style'
 import { renderCorner, renderEnd, renderGap } from '../utils/svg'
-import { getRotate } from '../utils/math'
+import { rotate } from '../utils/math'
 import Defs from './Defs'
 import Element from './Element'
 
@@ -50,7 +50,7 @@ const Panel = ({ panel, width, height }) => {
           const edges = []
           const endElement = getEndElement(nodeX, nodeY)
           if (endElement) {
-            const endPosition = getRotate(0, -lineWidth, endElement.dir)
+            const endPosition = rotate(0, -lineWidth, endElement.dir)
             const endX = nodeX + endPosition.x
             const endY = nodeY + endPosition.y
             edges.push([endElement.dir, { x: endX, y: endY }])

--- a/frontend/src/utils/math.js
+++ b/frontend/src/utils/math.js
@@ -2,21 +2,19 @@ const mod360 = value => (value + 360) % 360
 
 const toRads = degrees => degrees * Math.PI / 180
 
-const round2dp = value => Math.round(value * 100) / 100
+export const round3dp = value => Math.round(value * 1000) / 1000
 
 export const getAngleBetween = (inAngle, outAngle) =>
   mod360(outAngle - inAngle + 180)
 
-export const getRotate = (x, y, angle) => {
+// Rotates a set of x and y coordinates by a specified number of degrees
+export const rotate = (x, y, angle) => {
   const rads = toRads(angle)
   return {
-    x: round2dp((x * Math.cos(rads)) - (y * Math.sin(rads))),
-    y: round2dp((x * Math.sin(rads)) + (y * Math.cos(rads))),
+    x: (x * Math.cos(rads)) - (y * Math.sin(rads)),
+    y: (x * Math.sin(rads)) + (y * Math.cos(rads)),
   }
 }
-
-export const getScaledVector = (vector, scale) =>
-  round2dp(vector * scale)
 
 // Given the specified angle, calculates the x and y coordinates of a position
 // on the perimeter of a unit circle around the origin where the tangent
@@ -33,34 +31,17 @@ export const getNormal = (angle) => {
 // Calculates the x and y coordinates of the intersection of two tangent lines,
 // given both angles.
 export const getIntersection = (inAngle, outAngle) => {
-  const inNormal = getNormal(inAngle)
-  const outNormal = getNormal(outAngle)
+  // The math is more straightforward if one of the angles is vertical,
+  // so we assume the in angle is vertical, normalize the out angle relative
+  // to it and calculate y (x is -1). Then we just rotate the result by
+  // the original in angle to get the correct result.
+  const normalizedOutAngle = mod360(outAngle - inAngle)
 
-  const inTan = Math.tan(toRads(inAngle + 90))
-  const outTan = Math.tan(toRads(outAngle + 90))
+  const outNormal = getNormal(normalizedOutAngle)
+  const outTan = Math.tan(toRads(normalizedOutAngle + 90))
+  const diff = outNormal.y - (outTan * outNormal.x)
 
-  const inDiff = outNormal.y - (outTan * outNormal.x)
-  const outDiff = inNormal.y - (inTan * inNormal.x)
+  const y = -outTan + diff
 
-  const inVertical = inAngle % 180 === 0
-  const outVertical = outAngle % 180 === 0
-
-  if (inVertical) {
-    return {
-      x: inNormal.x,
-      y: (outTan * inNormal.x) + inDiff
-    }
-  } else if (outVertical) {
-    return {
-      x: outNormal.x,
-      y: (inTan * outNormal.x) + outDiff
-    }
-  }
-
-  const x = (outDiff - inDiff) / (outTan - inTan)
-
-  return {
-    x: x,
-    y: (inTan * x) + outDiff
-  }
+  return rotate(-1, y, inAngle)
 }

--- a/frontend/src/utils/svg.js
+++ b/frontend/src/utils/svg.js
@@ -1,10 +1,16 @@
 import {
+  round3dp,
+  rotate,
   getAngleBetween,
-  getRotate,
   getNormal,
-  getIntersection,
-  getScaledVector
-} from './math.js'
+  getIntersection
+} from './math'
+
+const getRelativeCoords = (x, y, scale, point) => {
+  const newX = round3dp(x + (scale * point.x))
+  const newY = round3dp(y + (scale * point.y))
+  return `${newX},${newY}`
+}
 
 export const renderCorner = (x, y, inAngle, outAngle, halfLineWidth, initial = false) => {
   const operation = initial ? 'M' : 'L'
@@ -12,49 +18,38 @@ export const renderCorner = (x, y, inAngle, outAngle, halfLineWidth, initial = f
   if (joinAngle === 180) {
     return ''
   } else if (joinAngle === 0) {
-    const perpendicularDirection = inAngle + 90
-    const reverseDirection = inAngle + 180
-    const intersection1 = getIntersection(inAngle, perpendicularDirection)
-    const x1 = x + getScaledVector(intersection1.x, halfLineWidth)
-    const y1 = y + getScaledVector(intersection1.y, halfLineWidth)
-    const intersection2 = getIntersection(perpendicularDirection, reverseDirection)
-    const x2 = x + getScaledVector(intersection2.x, halfLineWidth)
-    const y2 = y + getScaledVector(intersection2.y, halfLineWidth)
-    return `${operation}${x1},${y1}L${x2},${y2}`
+    const perpendicularAngle = inAngle + 90
+    const reverseAngle = inAngle + 180
+    const corner1 = getRelativeCoords(x, y, halfLineWidth,
+      getIntersection(inAngle, perpendicularAngle))
+    const corner2 = getRelativeCoords(x, y, halfLineWidth,
+      getIntersection(perpendicularAngle, reverseAngle))
+    return `${operation}${corner1}L${corner2}`
   } else if (joinAngle < 180) {
-    const intersection = getIntersection(inAngle, outAngle)
-    const x1 = x + getScaledVector(intersection.x, halfLineWidth)
-    const y1 = y + getScaledVector(intersection.y, halfLineWidth)
-    return `${operation}${x1},${y1}`
+    const intersection = getRelativeCoords(x, y, halfLineWidth,
+      getIntersection(inAngle, outAngle))
+    return `${operation}${intersection}`
   }
 
-  const intersection1 = getNormal(inAngle)
-  const x1 = x + getScaledVector(intersection1.x, halfLineWidth)
-  const y1 = y + getScaledVector(intersection1.y, halfLineWidth)
-  const intersection2 = getNormal(outAngle)
-  const x2 = x + getScaledVector(intersection2.x, halfLineWidth)
-  const y2 = y + getScaledVector(intersection2.y, halfLineWidth)
-  return `${operation}${x1},${y1}A${halfLineWidth},${halfLineWidth},0,0,1,${x2},${y2}`
+  const normal1 = getRelativeCoords(x, y, halfLineWidth,
+    getNormal(inAngle))
+  const normal2 = getRelativeCoords(x, y, halfLineWidth,
+    getNormal(outAngle))
+  return `${operation}${normal1}A${halfLineWidth},${halfLineWidth},0,0,1,${normal2}`
 }
 
 export const renderEnd = (x, y, angle, halfLineWidth) => {
-  const corner1 = getRotate(-halfLineWidth, 0, angle)
-  const x1 = x + corner1.x
-  const y1 = y + corner1.y
-  const corner2 = getRotate(halfLineWidth, 0, angle)
-  const x2 = x + corner2.x
-  const y2 = y + corner2.y
-
-  return `L${x1},${y1}A${halfLineWidth},${halfLineWidth},0,0,1,${x2},${y2}`
+  const corner1 = getRelativeCoords(x, y, 1,
+    rotate(-halfLineWidth, 0, angle))
+  const corner2 = getRelativeCoords(x, y, 1,
+    rotate(halfLineWidth, 0, angle))
+  return `L${corner1}A${halfLineWidth},${halfLineWidth},0,0,1,${corner2}`
 }
 
 export const renderGap = (x, y, angle, halfLineWidth, halfGapWidth) => {
-  const corner1 = getRotate(-halfLineWidth, halfGapWidth, angle)
-  const x1 = x + corner1.x
-  const y1 = y + corner1.y
-  const corner2 = getRotate(halfLineWidth, halfGapWidth, angle)
-  const x2 = x + corner2.x
-  const y2 = y + corner2.y
-
-  return `L${x1},${y1}L${x2},${y2}`
+  const corner1 = getRelativeCoords(x, y, 1,
+    rotate(-halfLineWidth, halfGapWidth, angle))
+  const corner2 = getRelativeCoords(x, y, 1,
+    rotate(halfLineWidth, halfGapWidth, angle))
+  return `L${corner1}L${corner2}`
 }

--- a/frontend/src/utils/svg.test.js
+++ b/frontend/src/utils/svg.test.js
@@ -40,7 +40,7 @@ describe('renderEnd', () => {
 
   test('45 degrees', () => {
     const result = renderEnd(3.29, 3.71, 45, 0.3)
-    expect(result).toBe('L3.08,3.5A0.3,0.3,0,0,1,3.5,3.92')
+    expect(result).toBe('L3.078,3.498A0.3,0.3,0,0,1,3.502,3.922')
   })
 })
 
@@ -52,6 +52,6 @@ describe('renderGap', () => {
 
   test('45 degrees', () => {
     const result = renderGap(5, 5, 45, 0.3, 0.15)
-    expect(result).toBe('L4.68,4.89L5.11,5.32')
+    expect(result).toBe('L4.682,4.894L5.106,5.318')
   })
 })


### PR DESCRIPTION
Massively simplified the logic of `getIntersection`. It now calculates the coordinates by rotating the lines so that one of them is vertical. This makes the x coordinate trivial (i.e. the x coordinate of the vertical line). After the calculation for the y coordinate is done, x and y are rotated back. 